### PR TITLE
Use GameObject transform for GLTFScenes

### DIFF
--- a/Assets/GLTF/Scripts/GLTFScene.cs
+++ b/Assets/GLTF/Scripts/GLTFScene.cs
@@ -22,7 +22,7 @@ namespace GLTF
         public GameObject Create(GameObject gltfRoot)
         {
             GameObject sceneObj = new GameObject(name ?? "GLTFScene");
-            sceneObj.transform.parent = gltfRoot.transform;
+            sceneObj.transform.SetParent(gltfRoot.transform, false);
 
             foreach (var node in nodes)
             {


### PR DESCRIPTION
Previously, the object's transform would be cancelled out, and the scene would always spawn at world origin.